### PR TITLE
Minor volume column porta fix

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -489,7 +489,7 @@ static void xm_handle_note_and_instrument(xm_context_t* ctx, xm_channel_context_
 
 	case 0xF: /* Tone portamento */
 		if(s->volume_column & 0x0F) {
-			ch->tone_portamento_param = (s->volume_column & 0x0F);
+			ch->tone_portamento_param = (s->volume_column & 0x0F) << 4;
 		}
 		break;
 

--- a/src/play.c
+++ b/src/play.c
@@ -489,7 +489,7 @@ static void xm_handle_note_and_instrument(xm_context_t* ctx, xm_channel_context_
 
 	case 0xF: /* Tone portamento */
 		if(s->volume_column & 0x0F) {
-			ch->tone_portamento_param = s->volume_column;
+			ch->tone_portamento_param = (s->volume_column & 0x0F);
 		}
 		break;
 


### PR DESCRIPTION
So I'm looking into the porta issues in #1, specifically the file [aurora_dawn.xm](http://modarchive.org/module.php?149875).

I haven't yet cracked why it sounds so interesting (Milky sounds like it's not even applying porta to the note, I think it might be something to do with the tempo and ticks, seeing what I'm reading through a few docs. Maybe something with how we do ``SLIDE_TOWARDS`` or ``update_frequency``), but I'm gonna try and keep plodding along with it and see what I find.

But I did find this issue, which is why that big spike was happening. It was taking the effect number as well as the actual effect value  (instead of 7 there, it was grabbing a much larger number because of the ``M``).

I haven't had a *good* look around at xm implementations, and I haven't done much audio work before, but I think porta's only meant to slide towards between the current and new note, right? I find it odd that even a larger than normal ``tone_portamento_param`` would make the note frequency spike – if anything, I'd expect it to just go between the two notes much faster than usual. But again, I'm not too familiar with XM, so I'll keep plodding along and see if I can work out the issue!

**edit:** Having a play with MT, it looks like it is just doing the porta very fast, I suspect due to the tempo variable I saw some documentation about a bit earlier. I'll do some testing and see if I can get libxm sounding just like MT/etc sounds.