### PR TITLE
Fixes values spiking due to bad sample memory accesses

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -1,4 +1,5 @@
 /* Author: Romain "Artefact2" Dalmaso <artefact2@gmail.com> */
+/* Contributor: Daniel Oaks <daniel@danieloaks.net> */
 
 /* This program is free software. It comes without any warranty, to the
  * extent permitted by applicable law. You can redistribute it and/or
@@ -1209,6 +1210,9 @@ static float xm_next_of_sample(xm_channel_context_t* ch) {
 		}
 		return .0f;
 	}
+	if(ch->sample->length == 0) {
+		return .0f;
+	}
 
 	float u, v, t;
 	uint32_t a, b;
@@ -1262,6 +1266,11 @@ static float xm_next_of_sample(xm_channel_context_t* ch) {
 				ch->ping = false;
 				ch->sample_position = (ch->sample->loop_end << 1) - ch->sample_position;
 			}
+			/* sanity checking */
+			if(ch->sample_position >= ch->sample->length) {
+				ch->ping = false;
+				ch->sample_position -= ch->sample->length - 1;
+			}
 		} else {
 			if(XM_LINEAR_INTERPOLATION) {
 				v = u;
@@ -1270,6 +1279,11 @@ static float xm_next_of_sample(xm_channel_context_t* ch) {
 			if(ch->sample_position <= ch->sample->loop_start) {
 				ch->ping = true;
 				ch->sample_position = (ch->sample->loop_start << 1) - ch->sample_position;
+			}
+			/* sanity checking */
+			if(ch->sample_position <= .0f) {
+				ch->ping = true;
+				ch->sample_position = .0f;
 			}
 		}
 		break;


### PR DESCRIPTION
This fixes the clicks and staticy noises in the modules in #1. That is, the ones that make these messages:
```
xm_sample(): final sample value is 136597905678638606450688.000000, this is a bug
xm_sample(): final sample value is 296616456960244306673664.000000, this is a bug
xm_sample(): final sample value is 144714319948683478564864.000000, this is a bug
```

There are two things that cause this problem in the ``xm_next_of_sample(xm_channel_context_t* ch)`` function – either the sample length is 0, and when it grabs ``u = ch->sample->data[a];`` it reads into memory that does not belong to it, so we have that if at the start to check the sample length is more than zero.

What can also happen is that the 'loop end point' extends past the actual end of the sample. Just by one tick, so ``ch->sample_position`` was getting set to 132 at the end of a sample that was only 132 long, resulting in the same sort of read into memory that does not belong to it.

Anyways, this fixes both of those issues and the clipping. I'm fairly sure Milkytracker handles this in the same way, clamping the loop end to the sample length.

**edit:** I'm not sure whether this sort of fix should also be applied to the other loop types. I had to quickly type this up a few minutes before running to work, but otherwise I'll look into it when I get home.