### PR TITLE
Make AU header 28 bytes to conform to specification and prevent sox warning

### DIFF
--- a/examples/xmtoau.c
+++ b/examples/xmtoau.c
@@ -41,11 +41,12 @@ int main(int argc, char** argv) {
 	xm_set_max_loop_count(ctx, 1);
 
 	puts_uint32_be(0x2E736E64); /* .snd magic number */
-	puts_uint32_be(24); /* Header size */
+	puts_uint32_be(28); /* Header size */
 	puts_uint32_be((uint32_t)(-1)); /* Data size, unknown */
 	puts_uint32_be(6); /* Encoding: 32-bit IEEE floating point */
 	puts_uint32_be(rate); /* Sample rate */
 	puts_uint32_be(channels); /* Number of interleaved channels */
+	puts_uint32_be(0); /* Optional text information */
 
 	while(xm_get_loop_count(ctx) == 0) {
 		xm_generate_samples(ctx, buffer, sizeof(buffer) / (channels * sizeof(float)));


### PR DESCRIPTION
Just a little patch. Basically, `xm2au ... | play -` outputs this warning:

```
play WARN au: header size 24 is too small
```

This is because sox (the `play` utility) uses a newer version of the AU spec, [here](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AU/AU.html).

This PR simply ups the header size and outputs the optional text information, makes it compliant to the spec and prevents that warning when playing.