### PR TITLE
Fixes for xmtowav example

### DIFF
--- a/examples/xmtowav.c
+++ b/examples/xmtowav.c
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 	if(ctx == NULL) exit(1);
 	xm_set_max_loop_count(ctx, 1);
 
-	out = fopen(argv[2], "w");
+	out = fopen(argv[2], "wb");
 	if(out == NULL) FATAL_ERR("could not open output file for writing");
 
 	/* WAVE format info taken from

--- a/examples/xmtowav.c
+++ b/examples/xmtowav.c
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
 	fseek(out, 4, SEEK_SET);
 	puts_uint32_le(36 + num_samples * sizeof(float), out);
 
-	fseek(out, 32, SEEK_SET);
+	fseek(out, 40, SEEK_SET);
 	puts_uint32_le(num_samples * sizeof(float), out);
 
 	fclose(out);


### PR DESCRIPTION
Writes the data chunk size in the correct spot, and specifies to open the output file as binary (so it works on Windows systems).

I also have two other branches, one with a few modifications for building on Windows with MSVC and another that adds support for generating 16-bit PCM samples. Let me know if you're interested in merging either of these.