### PR TITLE
Fix loading of instruments with non-standard sizes.

### DIFF
--- a/src/xm_internal.h
+++ b/src/xm_internal.h
@@ -30,6 +30,7 @@ extern int __fail[-1];
 /* ----- XM constants ----- */
 
 #define SAMPLE_NAME_LENGTH 22
+#define INSTRUMENT_HEADER_LENGTH 263
 #define INSTRUMENT_NAME_LENGTH 22
 #define MODULE_NAME_LENGTH 20
 #define TRACKER_NAME_LENGTH 20


### PR DESCRIPTION
While loading an instrument, the original FT2 loaded the instrument
header into a zeroed datastructure (possibly with a direct single read),
fetching as many bytes as declared in the file as header size.

This means that it is actually well defined to have an instrument whose
size is smaller than the standard one (263): what happens is that all
remaining fields are simply zeroed out.

This property was exploited by a XM compressor tool (BoobieSqueezer),
so there are modules floating around that actually have instruments
with smaller headers.

This PR fixes loading of such instruments by loading the headers into a
separate, zeroed buffer before actually parsing them.

Co-developed with @bryc that helped me a lot in researching the correct
solution.