### PR TITLE
Add missing include

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -8,6 +8,7 @@
  * http://sam.zoy.org/wtfpl/COPYING for more details. */
 
 #include "xm_internal.h"
+#include <inttypes.h>
 
 /* ----- Static functions ----- */
 


### PR DESCRIPTION
inttypes.h is required for "PRId32"