### PR TITLE
Fix arpeggio + vibrato in linear frequencies

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -353,7 +353,7 @@ static float xm_frequency(xm_context_t* ctx, float period, float note_offset, fl
 	switch(ctx->module.frequency_type) {
 
 	case XM_LINEAR_FREQUENCIES:
-		return xm_linear_frequency(period - 64.f * note_offset - 16.f * period_offset);
+		return xm_linear_frequency(period - 16.f * period_offset) - 64.f * note_offset;
 
 	case XM_AMIGA_FREQUENCIES:
 		if(note_offset == 0) {


### PR DESCRIPTION
In #27, we refactored xm_frequency to split arpeggio (note offset) from
vibrato (period offset). Unfortunately, we did test it properly only
for amiga frequencies.

It turns out the linear frequency implementation is wrong. The note
offset cannot be added to the period, but must be added to the note
itself. In case of linear frequencies, that's trivial to do once we
get the frequency, as we can simply scale it.

This fixes binary_world.xm and so finally...

Closes #1