### PR TITLE
Fix: VOLUME_EFFECT_VIBRATO_SPEED flag check fixed

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -382,7 +382,7 @@ static void xm_fixup_common(xm_context_t* ctx) {
 		}
 
 		#if HAS_VOLUME_COLUMN
-		if((slot->volume_column >> 8) == VOLUME_EFFECT_VIBRATO_SPEED
+		if((slot->volume_column >> 4) == VOLUME_EFFECT_VIBRATO_SPEED
 		   && (slot->volume_column & 0xF) == 0) {
 			/* Delete S0, it does nothing and saves a check in
 			   play.c. */


### PR DESCRIPTION
Looks like a typo: slot->volume_column has type uint8_t.

According to https://www.celersms.com/doc/XM_file_format.pdf

Volume column byte:
A0..AF U Vibrato speed (0..15)

and in your header:

#define VOLUME_EFFECT_VIBRATO_SPEED 0xA