### PR TITLE
Add fallback for missing stdbit.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ project(libxm LANGUAGES C)
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
+include(CheckIncludeFile)
+
 add_library(xm_common INTERFACE)
 if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang)$")
 	target_compile_options(xm_common INTERFACE
@@ -28,6 +30,13 @@ set_target_properties(xm PROPERTIES SOVERSION 11)
 find_library(MATH_LIBRARY m REQUIRED)
 target_include_directories(xm SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(xm PRIVATE xm_common ${MATH_LIBRARY})
+
+# Check if stdbit.h is available
+check_include_file(stdbit.h HAVE_STDBIT_H)
+
+if (NOT HAVE_STDBIT_H)
+	target_include_directories(xm SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/compat)
+endif()
 
 function(option_and_define name description default_value)
 	option(${name} ${description} ${default_value})

--- a/src/compat/stdbit.h
+++ b/src/compat/stdbit.h
@@ -1,0 +1,14 @@
+/* Author: danct12 <danct12@demodiv.danctnix.org> */
+
+/* This program is free software. It comes without any warranty, to the
+ * extent permitted by applicable law. You can redistribute it and/or
+ * modify it under the terms of the Do What The Fuck You Want To Public
+ * License, Version 2, as published by Sam Hocevar. See
+ * http://sam.zoy.org/wtfpl/COPYING for more details. */
+
+#ifndef __FALLBACK_STDBIT_H__
+#define __FALLBACK_STDBIT_H__
+
+#define stdc_count_ones __builtin_stdc_count_ones
+
+#endif /* __FALLBACK_STDBIT_H__ */


### PR DESCRIPTION
Some libc does not provide stdbit.h. But the compiler does support the functions in it.

This should allow libxm to build on MinGW with GCC 16.